### PR TITLE
add clean task

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 export PATH := ./node_modules/.bin:$(PATH)
 
+clean:
+	rm -rf bower_components node_modules
+
 install:
 	@npm install
 


### PR DESCRIPTION
in the `Makefile`
## Background
### Why aren't we using n-makefile here?

This isn't using `n-makefile` because this uses hot loading for rapid JS/CSS development.   Not had the time to look at this more.
