### PR TITLE
Revert "use Amazon API Gateway instead of the Heroku app"

### DIFF
--- a/data/api.js
+++ b/data/api.js
@@ -15,11 +15,11 @@ function post (url, emailAddresses, articleId) {
 export default class {
 
 	creditInfo () {
-		return fetch('/article-email/credits', { credentials: 'same-origin' })
+		return fetch('/rtcl-email/actions/credits', { credentials: 'same-origin' })
 	}
 
 	gift (emailAddresses, articleId) {
-		return post('/article-email/gift', emailAddresses, articleId)
+		return post('/rtcl-email/actions/gift', emailAddresses, articleId)
 	}
 
 	nonGift (emailAddresses, articleId) {


### PR DESCRIPTION
The credit information seems to be cached somewhere, so I'm reverting back to the Heroku app.

This reverts commit 150993e740d6d6818753d489adea56bb4c3cde87.
