### PR TITLE
use Amazon API Gateway and AWS Lambda instead of Heroku

### DIFF
--- a/data/api.js
+++ b/data/api.js
@@ -15,15 +15,15 @@ function post (url, emailAddresses, articleId) {
 export default class {
 
 	creditInfo () {
-		return fetch('/rtcl-email/actions/credits', { credentials: 'same-origin' })
+		return fetch('/article-email/credits', { credentials: 'same-origin' })
 	}
 
 	gift (emailAddresses, articleId) {
-		return post('/rtcl-email/actions/gift', emailAddresses, articleId)
+		return post('/article-email/gift', emailAddresses, articleId)
 	}
 
 	nonGift (emailAddresses, articleId) {
-		return post('/rtcl-email/actions/send', emailAddresses, articleId)
+		return post('/article-email/send', emailAddresses, articleId)
 	}
 
 }


### PR DESCRIPTION
for the API calls, two (credit & gift) to legacy gift system using Amazon API gateway, and one (non-gift send) to AWS Lambda
