### PR TITLE
automagically handle commas as what they are

### DIFF
--- a/components/email-address-list.js
+++ b/components/email-address-list.js
@@ -21,7 +21,7 @@ function giftNote (items, isGift, credit) {
 }
 
 function inputs (items, errors, onItemChange, onAdd, onRemove, isGift, credit) {
-	const maxItems = Math.min(isGift ? credit : 10, 4)
+	const maxItems = isGift ? credit : 10
 	return items.map((address, index) => {
 		const error = !errors[index] ? null : (
 			<div className="email-address__error o-forms-errortext">Please enter a valid email</div>
@@ -39,7 +39,9 @@ function inputs (items, errors, onItemChange, onAdd, onRemove, isGift, credit) {
 		return (
 				<div key={index} className={`email-address__item o-forms-group ${error ? 'o-forms--error' : ''}`}>
 					<div className="email-address__input-button">
-						<input type="email" className="o-forms-text email-address__input" value={address}
+						<input type="email" className="o-forms-text email-address__input"
+								autoFocus={true}
+								value={address}
 								onChange={event => onItemChange(index, event.target.value)}></input>
 						{button}
 					</div>

--- a/data/state.js
+++ b/data/state.js
@@ -67,9 +67,14 @@ export default function reducer (state = defaultState, action) {
 					else return Object.assign({}, state, { isGift: action.isGift })
 
 		case actions.EMAIL_ADDRESS_CHANGE:
-					return Object.assign({}, state, {
-						emailAddresses: state.emailAddresses.map((x, i) => i === action.index ? action.value : x)
-					})
+					const maxItems = state.isGift ? state.credit : 10;
+					const changed = action.value.split(',')
+						// up to the maximum number of email addresses
+						.slice(0, maxItems - state.emailAddresses.length + 1);
+					const all = state.emailAddresses.slice(0, action.index)
+						.concat(changed)
+						.concat(state.emailAddresses.slice(action.index + 1));
+					return Object.assign({}, state, { emailAddresses: all });
 
 		case actions.ADD_EMAIL_ADDRESS:
 					return Object.assign({}, state, {

--- a/data/state.js
+++ b/data/state.js
@@ -67,6 +67,9 @@ export default function reducer (state = defaultState, action) {
 					else return Object.assign({}, state, { isGift: action.isGift })
 
 		case actions.EMAIL_ADDRESS_CHANGE:
+					// some users comma-separate addresses in a single field
+					// so we split them up into separate fields
+					// and ignore anything over the maximum number allowed
 					const maxItems = state.isGift ? state.credit : 10;
 					const changed = action.value.split(',')
 						// up to the maximum number of email addresses


### PR DESCRIPTION
we've noticed that there's been about 20 attempts each day from users enter comma-separated email addresses in the gift article email input box, and so this PR expands this into separate email address boxes automagically

this PR also autofocusses on new email address field when it appears

we're also increasing to 10 from 4 the maximum number of email addresses that can be listed
